### PR TITLE
IP address updates

### DIFF
--- a/src/highlighter.rs
+++ b/src/highlighter.rs
@@ -115,13 +115,13 @@ impl HighlightBuilder {
             .try_add_highlighter(DateDashHighlighter::new(config))
     }
 
-    pub fn with_ip_v4_highlighter(&mut self, config: IpV4Config) -> &mut Self {
-        self.try_add_highlighter(IpV4Highlighter::new(config));
+    pub fn with_ip_v6_highlighter(&mut self, config: IpV6Config) -> &mut Self {
+        self.try_add_highlighter(IpV6Highlighter::new(config));
         self
     }
 
-    pub fn with_ip_v6_highlighter(&mut self, config: IpV6Config) -> &mut Self {
-        self.try_add_highlighter(IpV6Highlighter::new(config));
+    pub fn with_ip_v4_highlighter(&mut self, config: IpV4Config) -> &mut Self {
+        self.try_add_highlighter(IpV4Highlighter::new(config));
         self
     }
 

--- a/src/highlighters/ip_v6.rs
+++ b/src/highlighters/ip_v6.rs
@@ -2,6 +2,7 @@ use crate::highlighter::Highlight;
 use crate::IpV6Config;
 use nu_ansi_term::Style as NuStyle;
 use regex::{Captures, Error, Regex};
+use std::net::Ipv6Addr;
 
 pub struct IpV6Highlighter {
     regex: Regex,
@@ -12,7 +13,7 @@ pub struct IpV6Highlighter {
 
 impl IpV6Highlighter {
     pub fn new(config: IpV6Config) -> Result<Self, Error> {
-        let regex = Regex::new(r#"(?x) (?:[0-9a-fA-F]{1,4}:{1,2}) {3,}[0-9a-fA-F]{1,4}"#)?;
+        let regex = Regex::new(r#"(?:[0-9a-fA-F\:\.]{3,})"#)?;
 
         Ok(Self {
             regex,
@@ -26,22 +27,17 @@ impl IpV6Highlighter {
 impl Highlight for IpV6Highlighter {
     fn apply(&self, input: &str) -> String {
         self.regex
-            .replace_all(input, |caps: &Captures<'_>| {
-                let text = &caps[0];
-                if !text.chars().any(|c| matches!(c, 'a'..='f' | 'A'..='F')) {
-                    // If no hexadecimal letters are found, return the original text unmodified
-                    text.to_string()
-                } else {
-                    // Apply highlighting as before
-                    text.chars()
-                        .map(|c| match c {
-                            '0'..='9' => self.number.paint(c.to_string()).to_string(),
-                            'a'..='f' | 'A'..='F' => self.letter.paint(c.to_string()).to_string(),
-                            ':' | '.' => self.separator.paint(c.to_string()).to_string(),
-                            _ => c.to_string(),
-                        })
-                        .collect::<String>()
-                }
+            .replace_all(input, |caps: &Captures<'_>| match caps[0].parse::<Ipv6Addr>() {
+                Ok(_ip) => caps[0]
+                    .chars()
+                    .map(|c| match c {
+                        '0'..='9' => self.number.paint(c.to_string()).to_string(),
+                        'a'..='f' | 'A'..='F' => self.letter.paint(c.to_string()).to_string(),
+                        ':' | '.' => self.separator.paint(c.to_string()).to_string(),
+                        _ => c.to_string(),
+                    })
+                    .collect::<String>(),
+                Err(_err) => caps[0].to_string(),
             })
             .to_string()
     }
@@ -56,7 +52,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_ip_v4_highlighter() {
+    fn test_ip_v6_highlighter() {
         let highlighter = IpV6Highlighter::new(IpV6Config {
             number: Style::new().fg(Color::Blue),
             letter: Style::new().fg(Color::Yellow),
@@ -73,6 +69,12 @@ mod tests {
                 "2001:db8::ff00:42:8329",
                 "[blue]2[reset][blue]0[reset][blue]0[reset][blue]1[reset][red]:[reset][yellow]d[reset][yellow]b[reset][blue]8[reset][red]:[reset][red]:[reset][yellow]f[reset][yellow]f[reset][blue]0[reset][blue]0[reset][red]:[reset][blue]4[reset][blue]2[reset][red]:[reset][blue]8[reset][blue]3[reset][blue]2[reset][blue]9[reset]"
             ),
+            (
+                "::1",
+                "[red]:[reset][red]:[reset][blue]1[reset]"),
+            (
+                "::ffff:127.0.0.1",
+                "[red]:[reset][red]:[reset][yellow]f[reset][yellow]f[reset][yellow]f[reset][yellow]f[reset][red]:[reset][blue]1[reset][blue]2[reset][blue]7[reset][red].[reset][blue]0[reset][red].[reset][blue]0[reset][red].[reset][blue]1[reset]"),
             ("Not ipv4: 192.168.0.1", "Not ipv4: 192.168.0.1"),
             ("11:47:39:850", "11:47:39:850"),
         ];


### PR DESCRIPTION
* Support IPv4 mapped IPv6 addresses

  Support IPv4 mapped IPv6 addresses like ::ffff:127.0.0.1 and short ones like ::1.

  Highlight IPv6 before IPv4 addresses to avoid IPv4 highlighting parts of such IPv4 mapped IPv6 addresses.

  Since matching all valid IPv6 addresses via a regular expression is very hand, use a relaxed regular expression and then try to parse matches via the IPv6 parser.

* Support IP CIDR notation

  Highlight IP addresses including netmasks in the CIDR notation, like 192.168.0.0/24.

Split from #2